### PR TITLE
Update misleading error and give resolution hints

### DIFF
--- a/src/GitVersion.Core/Configuration/BranchConfigurationCalculator.cs
+++ b/src/GitVersion.Core/Configuration/BranchConfigurationCalculator.cs
@@ -132,7 +132,7 @@ namespace GitVersion.Configuration
                 {
                     // TODO We should call the build server to generate this exception, each build server works differently
                     // for fetch issues and we could give better warnings.
-                    throw new InvalidOperationException("Could not find a 'develop' or 'main' branch, neither locally nor remotely.");
+                    throw new InvalidOperationException("Gitversion could not determine which branch to treat as the development branch (default = develop) nor release branch (default = main or master), neither locally nor remotely. Ensure the local clone and checkout match the requirements or considering using 'Gitversion Dynamic Repositories'");
                 }
 
                 log.Warning($"{errorMessage}{System.Environment.NewLine}Falling back to {chosenBranch} branch config");


### PR DESCRIPTION
Fixes #2598

Previous message sounded like literal branches rather than Gitversion branch "types".  Also gave hints on checking local repo meets Gitversion requirements or to use dynamic repositories.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Previous message sounded like literal branches rather than Gitversion branch "types".  Also gave hints on checking local repo meets Gitversion requirements or to use dynamic repositories.

## Motivation and Context
The existing error message tries to use quotes to indicate these are not actual branch names - but this is easily misleading as the quotes can be taken to mean literalness rather than "Gitversion develop".  The problem can also occur when the local repository clone or checkout do not follow the requirements, but the literal branches "develop" and "main" are actually  present.

## How Has This Been Tested?
It's just a message text change.

## Screenshots (if appropriate):

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
