### PR TITLE
Enhancing GitLab info via working example of GitVersion

### DIFF
--- a/docs/input/docs/reference/build-servers/gitlab.md
+++ b/docs/input/docs/reference/build-servers/gitlab.md
@@ -7,3 +7,17 @@ Description: Details on the GitLab CI support in GitVersion
 To use GitVersion with GitLab CI, either use the [MSBuild
 Task](/docs/usage/msbuild) or put the GitVersion executable in your
 runner's `PATH`.
+
+A working example of integrating GitVersion with GitLab is maintained in the project [Utterly Automated Software and Artifact Versioning with GitVersion](https://gitlab.com/guided-explorations/devops-patterns/utterly-automated-versioning/)
+
+Here is a summary of what it demonstrated (many more details in the [README.md](https://gitlab.com/guided-explorations/devops-patterns/utterly-automated-versioning/-/blob/develop/README.md))
+
+- Is a working example know as a [Guided Explorations (GE Manifesto)](https://gitlab.com/guided-explorations/guided-exploration-concept/-/blob/master/README.md) - so job logs and package artifacts can be reviewed. The project can also be imported to your own GitLab group or instance.
+- Implements GitVersion as a CI CD Extension that can be reused across many projects on the same GitLab instance using includes.
+- Implements GitVersion as a single job that runs the GitVersion container and passes the version number downstream into both PIPLINE and JOB level variables, which means...
+- It can be used with ANY coding language, framework or packaging engine.
+- Generates example packaged artifacts:
+  - Two ways of building Sem Versioned [NuGet packages](https://docs.gitlab.com/ee/user/packages/nuget_repository/) (msbuild-ish and nuget.exe-ish) and uploads them and tests them from a [GitLab NuGet repository](https://docs.gitlab.com/ee/user/packages/nuget_repository/).
+  - A Sem Versioned [GitLab "Generic Package"](https://docs.gitlab.com/ee/user/packages/generic_packages/)
+  - A Sem Versioned docker container and uploads to [GitLabs Container Registry](https://docs.gitlab.com/ee/user/packages/container_registry/).
+- It creates a Sem Versioned [GitLab Release](GitLab Releases Feature Help) and Git tag using the [GitLab release-cli](https://gitlab.com/gitlab-org/release-cli/-/tree/master/docs) and links the generic package as evidence.

--- a/docs/input/docs/reference/build-servers/gitlab.md
+++ b/docs/input/docs/reference/build-servers/gitlab.md
@@ -13,6 +13,7 @@ A working example of integrating GitVersion with GitLab is maintained in the pro
 Here is a summary of what it demonstrated (many more details in the [README.md](https://gitlab.com/guided-explorations/devops-patterns/utterly-automated-versioning/-/blob/develop/README.md))
 
 - Is a working example know as a [Guided Explorations (GE Manifesto)](https://gitlab.com/guided-explorations/guided-exploration-concept/-/blob/master/README.md) - so job logs and package artifacts can be reviewed. The project can also be imported to your own GitLab group or instance.
+- IMPORTANT: It demonstrates how to override GitLab CI's default cloning behavior so that GitVersion can do a dynamic copy. This best practice demonstrates the best way to do this while avoiding a double-cloning of the project (once by GitLab Runner and once by GitVersion)
 - Implements GitVersion as a CI CD Extension that can be reused across many projects on the same GitLab instance using includes.
 - Implements GitVersion as a single job that runs the GitVersion container and passes the version number downstream into both PIPLINE and JOB level variables, which means...
 - It can be used with ANY coding language, framework or packaging engine.


### PR DESCRIPTION
Links to a working example of GitLab integration

Provides a link and description of a best practice implementation of running GitVersion in GitLab CI.

Closes #2790

## Description
Please see the markdown in this PR.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The GitLab CI page does not have sufficient information for a reasonable starting point in being successful with that framework.

## How Has This Been Tested?
The linked example is a **Working Example**

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
